### PR TITLE
setup.cfg: remove build-time dependency on things unrelated to building

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,6 @@ setup_requires =
       cffi>=1.14.0
       setuptools-scm>=3.5.0
       setuptools>=42.0
-      wheel
-      pep517
 package_dir =
     =src
 packages = find:


### PR DESCRIPTION
pep517 is a command-line tool used by developers interested in building any package, it does not need to be listed as a requirement which `python -m pep517.build` installs into the isolated build environment.

wheel is used optionally by setuptools to run bdist_wheel and is required by the pep517 build backend... but this is only needed if
you're using pyproject.toml's build-system.requires, so this is a duplicate line.